### PR TITLE
[여진] yeojin slide #15-3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 
-# .env
+.env

--- a/src/components/Slides/ShortsSlide.jsx
+++ b/src/components/Slides/ShortsSlide.jsx
@@ -5,7 +5,10 @@ import "swiper/css";
 import PlusIcon from "../../images/icons/plusIcon.svg";
 import Arrow from "../../images/icons/main_banner_arr.svg";
 import { NaviLeftBtn, NaviRightBtn } from "./NaviBtnStyles";
-import { useYoutubePlaylist } from "../../hook/useYoutubePlaylist";
+import {
+  useYoutubePlaylist,
+  useYoutubeVideoDetails,
+} from "../../hook/useYoutubePlaylist";
 import Shortscard from "./Shortscard";
 
 const Title = styled.div`
@@ -91,7 +94,7 @@ const SlideContainer = styled.div`
   }
 `;
 
-const HighlightSlide = React.memo(({ playlistId, title, max }) => {
+const ShortsSlide = React.memo(({ playlistId, title, max }) => {
   const [swiper, setSwiper] = useState();
   const [isBeginning, setIsBeginning] = useState(true);
   const [isEnd, setIsEnd] = useState(false);
@@ -111,22 +114,35 @@ const HighlightSlide = React.memo(({ playlistId, title, max }) => {
     isError,
   } = useYoutubePlaylist(playlistId, max);
 
+  const videoIds = useMemo(() => {
+    return shorts
+      .map((item) => item.snippet.resourceId?.videoId || item.id?.videoId)
+      .filter(Boolean)
+      .join(",");
+  }, [shorts]);
+
+  const { data: details = [] } = useYoutubeVideoDetails(videoIds, !!videoIds);
+
   const slides = useMemo(() => {
-    return shorts.map((item) => {
-      const videoId = item.snippet.resourceId?.videoId || item.id.videoId;
-      const { title, thumbnails } = item.snippet;
+    return details.map((video) => {
+      const { id, snippet, statistics } = video;
 
       return (
-        <SwiperSlide key={videoId}>
+        <SwiperSlide key={id}>
           <Shortscard
-            thumbnail={thumbnails.maxres?.url || thumbnails.medium.url}
-            title={title}
-            onClick={() => console.log("Clicked:", videoId)}
+            thumbnail={
+              snippet.thumbnails?.maxres?.url || snippet.thumbnails?.medium?.url
+            }
+            title={snippet.title}
+            channelTitle={snippet.channelTitle}
+            views={statistics.viewCount}
+            likes={statistics.likeCount}
+            onClick={() => console.log("Clicked:", id)}
           />
         </SwiperSlide>
       );
     });
-  }, [shorts]);
+  }, [details]);
 
   if (isLoading) return <div>불러오는 중...</div>;
   if (isError) return <div>문제가 발생했어요.</div>;
@@ -204,4 +220,4 @@ const HighlightSlide = React.memo(({ playlistId, title, max }) => {
   );
 });
 
-export default HighlightSlide;
+export default ShortsSlide;

--- a/src/components/Slides/Shortscard.jsx
+++ b/src/components/Slides/Shortscard.jsx
@@ -32,7 +32,15 @@ const CardWrapper = styled.div`
   }
 `;
 
-const ShortsCard = ({ thumbnail, title, onClick }) => {
+const ShortsCard = ({
+  thumbnail,
+  title,
+  onClick,
+  channelTitle,
+  views,
+  likes,
+}) => {
+  console.log(channelTitle, views, likes);
   return (
     <Container>
       <CardWrapper onClick={onClick}>

--- a/src/hook/useYoutubePlayList.js
+++ b/src/hook/useYoutubePlayList.js
@@ -25,6 +25,20 @@ export const fetchYoutubePlaylist = async ({ queryKey }) => {
   return res.data.items || [];
 };
 
+const fetchVideoDetails = async ({ queryKey }) => {
+  const [_key, videoIds] = queryKey;
+
+  const res = await axios.get("https://www.googleapis.com/youtube/v3/videos", {
+    params: {
+      part: "snippet,statistics",
+      id: videoIds,
+      key: API_KEY,
+    },
+  });
+
+  return res.data.items;
+};
+
 export const useYoutubePlaylist = (
   playlistId,
   maxResults = 12,
@@ -39,5 +53,17 @@ export const useYoutubePlaylist = (
     cacheTime: 1000 * 60 * 10, // 10분간 쿼리 캐시 유지
     retry: 1,
     refetchOnWindowFocus: false, // 탭 이동 시 재요청 방지
+  });
+};
+
+export const useYoutubeVideoDetails = (videoIds, enabled = true) => {
+  return useQuery({
+    queryKey: ["youtubeVideoDetails", videoIds],
+    queryFn: fetchVideoDetails,
+    enabled: !!videoIds && enabled,
+    staleTime: 1000 * 60 * 5,
+    cacheTime: 1000 * 60 * 10,
+    retry: 1,
+    refetchOnWindowFocus: false,
   });
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -8,7 +8,7 @@ import bannerStrike from "../images/banners/banner-strike.png";
 import bannerStrike_m from "../images/banners/bannerStrike_mh.png";
 import PlaySlidewithTabs from "../components/Slides/PlaySlidewithTabs";
 import HomeList from "../components/Home/HomeList";
-import HighlightSlide from "../components/Slides/HighlightSlide";
+import ShortsSlide from "../components/Slides/ShortsSlide";
 import PopularPlayer from "../components/Home/PopularPlayer";
 import CollaboBanner from "../components/Home/CollaboBanner";
 import HomeProducts from "../components/Home/HomeProducts";
@@ -227,7 +227,7 @@ const Home = () => {
           <img src={bannerStrike_m} alt="banner" />
         </Link>
       </Banner>
-      <HighlightSlide
+      <ShortsSlide
         playlistId={"PLQPJYlrXc1__Lq54IZocnGImt8Ays8Y9W"}
         title={"하이라이트 CLIP"}
         max={21}


### PR DESCRIPTION
하이라이트 슬라이드 컴포넌트 -> 쇼츠 슬라이드 컴포넌트 이름변경(안헷갈리기 위함)
숏츠 슬라이드에 썸네일 + 타이틀 에서 채널명, 뷰, 좋아요수 정보 더 추가 (카드로 props 넘김) (카드에서 일단 콘솔로 값 나오게 해놓음)
페이지에 따라서 (url로 체크하는 방식이면 될거같은) 어느 페이지냐에 따라 카드 컴포넌트에서 채널명도 더 보이게 하는 식으로 커스텀을 하면 될 거 같아요. 그리고 클릭하면 등장하는 쇼츠 모달쪽으로는 이 정보값 모두 props로 넘겨서 거기서는 다 등장하게 하고.