### PR TITLE
[여진] 탑스케쥴 레이아웃 3칸 수정

### DIFF
--- a/src/components/TopSchedule.jsx
+++ b/src/components/TopSchedule.jsx
@@ -124,11 +124,36 @@ const TopSchedule = () => {
   const baseIndex = scheduleData.findIndex((item) => item.date >= today);
   const safeIndex = baseIndex !== -1 ? baseIndex : scheduleData.length - 1;
 
-  const threeDaySlice = [
-    scheduleData[safeIndex - 1],
-    scheduleData[safeIndex],
-    scheduleData[safeIndex + 1],
-  ].filter(Boolean);
+  // 첫째날, 마지막날 일정 체크
+  const isFirstDay = safeIndex === 0;
+  const isLastDay = safeIndex === scheduleData.length - 1;
+
+  // const threeDaySlice = [
+  //   scheduleData[safeIndex - 1],
+  //   scheduleData[safeIndex],
+  //   scheduleData[safeIndex + 1],
+  // ].filter(Boolean);
+
+  // 보여줄 3일 계산
+  const displayedDays = isLastDay
+    ? [
+        scheduleData[safeIndex - 2],
+        scheduleData[safeIndex - 1],
+        scheduleData[safeIndex],
+      ]
+    : isFirstDay
+    ? [
+        scheduleData[safeIndex],
+        scheduleData[safeIndex + 1],
+        scheduleData[safeIndex + 2],
+      ]
+    : [
+        scheduleData[safeIndex - 1],
+        scheduleData[safeIndex],
+        scheduleData[safeIndex + 1],
+      ];
+
+  const threeDaySlice = displayedDays.filter(Boolean);
 
   useEffect(() => {
     const updateScroll = ({ scroll }) => {


### PR DESCRIPTION
8월 31일로 일정 데이터가 끝나면서 탑스케쥴이 2개만 나와 레이아웃 깨짐 문제가 있어서 마지막일 기준으로 2일전, 1일전, 마지막일 이렇게 3개 일정카드 나오도록 수정했습니다.